### PR TITLE
fix: 修正故事卡和遭遇组图标位置偏移问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ output_card.png
 /global_config.json
 /官方卡重置/
 /remaek_card/官方卡重置/
+
+# 排除 近期打开的目录的 json 文件
+/recent_directories.json
+# 排除 python 编译缓存
+*/__pycache__

--- a/Card.py
+++ b/Card.py
@@ -951,7 +951,7 @@ class Card:
             '地点卡': {'center': (370, 518), 'default_size': (60, 60)},
             '敌人卡': {'center': (369, 574), 'default_size': (60, 60)},
             '诡计卡': {'center': (372, 536), 'default_size': (60, 60)},
-            '故事卡': {'center': (600, 98), 'default_size': (60, 60)},
+            '故事卡': {'center': (642, 98), 'default_size': (60, 60)},
             '冒险参考卡': {'center': (372, 152), 'default_size': (60, 60)},
             '密谋卡_正面': {'center': (742, 85), 'default_size': (60, 60)},
             '场景卡_正面': {'center': (282, 83), 'default_size': (60, 60)},

--- a/create_card.py
+++ b/create_card.py
@@ -1348,7 +1348,7 @@ class CardCreator:
 
         # 贴遭遇组
         if self.transparent_encounter and dp:
-            card.copy_circle_to_image(dp, (643, 92, 42), (600, 99, 42))
+            card.copy_circle_to_image(dp, (643, 92, 42), (643, 99, 42))
 
         card.draw_centered_text((313, 90), data['name'], "标题字体", 48, (0, 0, 0))
         card.draw_centered_text((370, 1008), '剧情', "卡牌类型字体", 30, (0, 0, 0))


### PR DESCRIPTION
1.调整故事卡图标中心坐标从(600, 98)到(642, 98)。
chore:更新.gitignore文件。2.排除近期目录记录和Python缓存文件。