### PR TITLE
feat: 场景卡、密谋卡背面标题添加竖排

### DIFF
--- a/Card.py
+++ b/Card.py
@@ -307,7 +307,8 @@ class Card:
             has_border=False,
             border_width=1,
             border_color=(0, 0, 0),
-            underline=False
+            underline=False,
+            is_vertical=False
     ):
         """
         在指定位置居中绘制文字，可选外边框
@@ -321,6 +322,7 @@ class Card:
         :param border_width: 边框粗细
         :param border_color: 边框颜色
         :param underline: 是否添加下划线
+        :param is_vertical: 是否竖排文本
         """
         if self.font_manager.silence:
             return
@@ -336,7 +338,8 @@ class Card:
                 has_border=has_border,
                 border_color=border_color,
                 border_width=border_width,
-                has_underline=underline
+                has_underline=underline,
+                is_vertical=is_vertical
             ),
         ))
         pass

--- a/create_card.py
+++ b/create_card.py
@@ -1308,12 +1308,15 @@ class CardCreator:
         small_words += data.get('serial_number', '')
         card.draw_centered_text((96, 68), small_words, "卡牌类型字体", 28, (0, 0, 0))
 
-        # 写标题
-        title = Card(450, 100, self.font_manager, self.image_manager)
-        title.draw_centered_text((225, 50), data['name'], "标题字体", 48, (0, 0, 0))
-        title_img = title.image.rotate(90, expand=True)
-        card.paste_image(title_img, (40, 208), 'cover')
+        # 写标题 原横排文本，可以加选项
+        # title = Card(450, 100, self.font_manager, self.image_manager)
+        # title.draw_centered_text((225, 50), data['name'], "标题字体", 48, (0, 0, 0))
+        # title_img = title.image.rotate(90, expand=True)
+        # card.paste_image(title_img, (40, 208), 'cover')
 
+        # 写竖排标题 坐标转置
+        card.draw_centered_text((98,406), data['name'], "标题字体", 48, (0, 0, 0),is_vertical=True)
+       
         # 写正文
         body = self._tidy_body_flavor(data['body'], data['flavor'], flavor_type=1, align='left', quote=True)
         offset = -8


### PR DESCRIPTION
- 在Card类和RichTextRenderer类中新增is_vertical参数控制是否为竖排文本
- 修改create_card.py使用竖排方式渲染标题
- RichTextRender实现竖排文本的逐字符处理和垂直布局计算