### PR TITLE
fix: 修复垂直文本中英混排时英文文本处理问题

### DIFF
--- a/rich_text_render/RichTextRenderer.py
+++ b/rich_text_render/RichTextRenderer.py
@@ -679,7 +679,7 @@ class RichTextRenderer:
                 font_name = font_stack.get_top_font_name()
                 text_content = item.content
 
-                if item.type == TextType.OTHER:
+                if item.type == TextType.OTHER  or (vertical & (item.type == TextType.ENGLISH)):
                     # 逐字符处理
                     for char in text_content:
                         text_box = self._get_text_box(char, font)


### PR DESCRIPTION
当在垂直排版模式下且文本类型为ENGLISH类型时，使用逐字符处理文本内容，取代原来的文本块。
