### PR TITLE
Fix:Fix FileTreePanel  when filelist overflow . (修复文件树内容超过一页滚动时，无法显示完整的问题) 

### DIFF
--- a/arkham-app/src/components/FileTreePanel.vue
+++ b/arkham-app/src/components/FileTreePanel.vue
@@ -3748,16 +3748,15 @@ defineExpose({
 /* 移动端文件树滚动优化 */
 @media (max-width: 768px) {
   .file-tree-pane {
-    height: 100vh;
-    max-height: 100vh;
+    height: calc(80vh - 64px);
+    max-height: calc(80vh - 64px);
   }
 
   .file-tree-content {
     padding: 8px;
-    /* 确保移动端滚动容器占满可用空间 */
-    height: calc(100vh - 60px); /* 减去头部高度 */
-    min-height: calc(100vh - 60px);
-    /* 增强滚动体验 */
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
     overscroll-behavior: contain;
     touch-action: pan-y;
   }


### PR DESCRIPTION
ix filetree UI . Some file cann`t be seen when filelist overflow . (修复文件树内容超过一页滚动时，无法显示完整的问题)
Before: 
![fee1627d82aa0eb9b6c13b3205e06d9](https://github.com/user-attachments/assets/4a09a494-d5f9-4acc-a9ca-402e769e3ffe)

After:
![23887f4db1ddc5e55b2480f7218ce45](https://github.com/user-attachments/assets/7952818e-8827-477f-ad6a-4cbf44b41123)
